### PR TITLE
Replaced the usage of 'RealityFoundation'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: build
+env:
+    DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Generate '.xcodeproj'
+      run: swift package generate-xcodeproj
+    - name: Build
+      run: |
+        xcodebuild build clean\
+         -scheme "RealityKitt-Package"\
+         -sdk iphonesimulator\
+         -destination "platform=iOS Simulator,name=iPhone 11 Pro Max,OS=14.0"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: lint
-        uses: norio-nomura/action-swiftlint@3.1.0
+      - name: SwiftLint
+        run: swiftlint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: test
+env:
+    DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Generate '.xcodeproj'
+      run: swift package generate-xcodeproj
+    - name: Test
+      run: |
+        xcodebuild clean test\
+         -scheme "RealityKitt-Package"\
+         -sdk iphonesimulator\
+         -destination "platform=iOS Simulator,name=iPhone 11 Pro Max,OS=14.0"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/RealityKitt/RealityFoundation/RealityFoundation.AnchorEntity+Simulator.swift
+++ b/Sources/RealityKitt/RealityFoundation/RealityFoundation.AnchorEntity+Simulator.swift
@@ -1,14 +1,14 @@
 #if targetEnvironment(simulator)
 
-import RealityFoundation
+import RealityKit
 
-// MARK: - RealityFoundation.AnchorEntity
+// MARK: - RealityKit.AnchorEntity
 
 @available(iOS 13.0, *)
-extension RealityFoundation.AnchorEntity {
+extension RealityKit.AnchorEntity {
 
-    public convenience init(plane: RealityFoundation.AnchoringComponent.Target.Alignment,
-                            classification: RealityFoundation.AnchoringComponent.Target.Classification = .any,
+    public convenience init(plane: RealityKit.AnchoringComponent.Target.Alignment,
+                            classification: RealityKit.AnchoringComponent.Target.Classification = .any,
                             minimumBounds: Swift.SIMD2<Swift.Float> = [0, 0]) {
         self.init(world: matrix_identity_float4x4)
     }

--- a/Sources/RealityKitt/RealityFoundation/RealityFoundation.AnchoringComponent+Simulator.swift
+++ b/Sources/RealityKitt/RealityFoundation/RealityFoundation.AnchoringComponent+Simulator.swift
@@ -1,13 +1,13 @@
 #if targetEnvironment(simulator)
 
 import Foundation
-import RealityFoundation
+import RealityKit
 
-// MARK: - RealityFoundation.AnchoringComponent.Target
+// MARK: - RealityKit.AnchoringComponent.Target
 
 // FIXME - Doc - it's not the same ;)
 @available(iOS 13.0, *)
-extension RealityFoundation.AnchoringComponent.Target {
+extension RealityKit.AnchoringComponent.Target {
 
     public static func anchor(identifier: Foundation.UUID) -> Self {
         .world(transform: matrix_identity_float4x4)
@@ -33,10 +33,10 @@ extension RealityFoundation.AnchoringComponent.Target {
 
 }
 
-// MARK: - RealityFoundation.AnchoringComponent.Target + Alignment
+// MARK: - RealityKit.AnchoringComponent.Target + Alignment
 
 @available(iOS 13.0, *)
-extension RealityFoundation.AnchoringComponent.Target {
+extension RealityKit.AnchoringComponent.Target {
 
     public struct Alignment : Swift.OptionSet {
 
@@ -62,10 +62,10 @@ extension RealityFoundation.AnchoringComponent.Target {
 
 }
 
-// MARK: - RealityFoundation.AnchoringComponent.Target + Classification
+// MARK: - RealityKit.AnchoringComponent.Target + Classification
 
 @available(iOS 13.0, *)
-extension RealityFoundation.AnchoringComponent.Target {
+extension RealityKit.AnchoringComponent.Target {
 
     public struct Classification : Swift.OptionSet {
 

--- a/Sources/RealityKitt/RealityFoundation/RealityFoundation.BodyTrackedEntity+Simulator.swift
+++ b/Sources/RealityKitt/RealityFoundation/RealityFoundation.BodyTrackedEntity+Simulator.swift
@@ -1,8 +1,8 @@
 #if targetEnvironment(simulator)
 
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.0, *)
-public class BodyTrackedEntity : RealityFoundation.Entity, HasBodyTracking, RealityFoundation.HasModel { }
+public class BodyTrackedEntity : RealityKit.Entity, HasBodyTracking, RealityKit.HasModel { }
 
 #endif

--- a/Sources/RealityKitt/RealityFoundation/RealityFoundation.BodyTrackingComponent+Simulator.swift
+++ b/Sources/RealityKitt/RealityFoundation/RealityFoundation.BodyTrackingComponent+Simulator.swift
@@ -1,10 +1,10 @@
 #if targetEnvironment(simulator)
 
 import Foundation
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.0, *)
-public struct BodyTrackingComponent : RealityFoundation.Component, Swift.Equatable {
+public struct BodyTrackingComponent : RealityKit.Component, Swift.Equatable {
 
     public enum Target : Swift.Hashable {
         case any

--- a/Sources/RealityKitt/RealityFoundation/RealityFoundation.Entity+Simulator.swift
+++ b/Sources/RealityKitt/RealityFoundation/RealityFoundation.Entity+Simulator.swift
@@ -1,10 +1,10 @@
 #if targetEnvironment(simulator)
 
 import Foundation
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.0, *)
-extension RealityFoundation.Entity {
+extension RealityKit.Entity {
 
     public static func loadBodyTracked(named name: Swift.String,
                                        in bundle: Foundation.Bundle? = nil) throws -> BodyTrackedEntity {
@@ -13,8 +13,8 @@ extension RealityFoundation.Entity {
 
     public static func loadBodyTrackedAsync(named name: Swift.String,
                                             in bundle: Foundation.Bundle? = nil)
-    -> RealityFoundation.LoadRequest<BodyTrackedEntity> {
-        // RealityFoundation.LoadRequest cannot be constructed because it has no accessible initializers.
+    -> RealityKit.LoadRequest<BodyTrackedEntity> {
+        // RealityKit.LoadRequest cannot be constructed because it has no accessible initializers.
         // Because of that we cannot return a failing load request. Instead, a `fatalError` is thrown.
         fatalError("loadBodyTrackedAsync(named:in:) has not been implemented")
     }
@@ -26,8 +26,8 @@ extension RealityFoundation.Entity {
 
     public static func loadBodyTrackedAsync(contentsOf url: Foundation.URL,
                                             withName resourceName: Swift.String? = nil)
-    -> RealityFoundation.LoadRequest<BodyTrackedEntity> {
-        // RealityFoundation.LoadRequest cannot be constructed because it has no accessible initializers.
+    -> RealityKit.LoadRequest<BodyTrackedEntity> {
+        // RealityKit.LoadRequest cannot be constructed because it has no accessible initializers.
         // Because of that we cannot return a failing load request. Instead, a `fatalError` is thrown.
         fatalError("loadBodyTrackedAsync(contentsOf:withName:) has not been implemented")
     }

--- a/Sources/RealityKitt/RealityFoundation/RealityFoundation.HasBodyTracking+Simulator.swift
+++ b/Sources/RealityKitt/RealityFoundation/RealityFoundation.HasBodyTracking+Simulator.swift
@@ -1,9 +1,9 @@
 #if targetEnvironment(simulator)
 
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.0, *)
-public protocol HasBodyTracking : RealityFoundation.HasTransform { }
+public protocol HasBodyTracking : RealityKit.HasTransform { }
 
 @available(iOS 13.0, *)
 extension HasBodyTracking {

--- a/Sources/RealityKitt/RealityFoundation/RealityFoundation.HasSceneUnderstanding+Simulator.swift
+++ b/Sources/RealityKitt/RealityFoundation/RealityFoundation.HasSceneUnderstanding+Simulator.swift
@@ -1,9 +1,9 @@
 #if targetEnvironment(simulator)
 
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.4, *)
-public protocol HasSceneUnderstanding : RealityFoundation.Entity { }
+public protocol HasSceneUnderstanding : RealityKit.Entity { }
 
 @available(iOS 13.4, *)
 extension HasSceneUnderstanding {

--- a/Sources/RealityKitt/RealityFoundation/RealityFoundation.SceneUnderstandingComponent+Simulator.swift
+++ b/Sources/RealityKitt/RealityFoundation/RealityFoundation.SceneUnderstandingComponent+Simulator.swift
@@ -1,9 +1,9 @@
 #if targetEnvironment(simulator)
 
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.4, *)
-public struct SceneUnderstandingComponent : RealityFoundation.Component {
+public struct SceneUnderstandingComponent : RealityKit.Component {
 
     public enum EntityType : Swift.Hashable {
         case meshChunk

--- a/Sources/RealityKitt/RealityKit/RealityKit.AnchorEntity+Simulator.swift
+++ b/Sources/RealityKitt/RealityKit/RealityKit.AnchorEntity+Simulator.swift
@@ -1,10 +1,10 @@
 #if targetEnvironment(simulator)
 
 import ARKit
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.0, *)
-extension RealityFoundation.AnchorEntity {
+extension RealityKit.AnchorEntity {
 
     public convenience init(anchor: ARKit.ARAnchor) {
         self.init(world: matrix_identity_float4x4)

--- a/Sources/RealityKitt/RealityKit/RealityKit.AnchoringComponent+Simulator.swift
+++ b/Sources/RealityKitt/RealityKit/RealityKit.AnchoringComponent+Simulator.swift
@@ -1,10 +1,10 @@
 #if targetEnvironment(simulator)
 
 import ARKit
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.0, *)
-extension RealityFoundation.AnchoringComponent {
+extension RealityKit.AnchoringComponent {
 
     public init(_ anchor: ARKit.ARAnchor) {
         self.init(.anchor(identifier: anchor.identifier))

--- a/Sources/RealityKitt/RealityKit/RealityKit.EntityGestureRecognizer+Simulator.swift
+++ b/Sources/RealityKitt/RealityKit/RealityKit.EntityGestureRecognizer+Simulator.swift
@@ -1,21 +1,21 @@
 #if targetEnvironment(simulator)
 
 import UIKit
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.0, *)
 public protocol EntityGestureRecognizer : UIKit.UIGestureRecognizer {
 
-    var entity: RealityFoundation.HasCollision? { get set }
+    var entity: RealityKit.HasCollision? { get set }
 
-    func location(in entity: RealityFoundation.Entity?) -> Swift.SIMD3<Swift.Float>?
+    func location(in entity: RealityKit.Entity?) -> Swift.SIMD3<Swift.Float>?
 
 }
 
 @available(iOS 13.0, *)
 extension EntityGestureRecognizer {
 
-    public func location(in entity: RealityFoundation.Entity?) -> Swift.SIMD3<Swift.Float>? { nil }
+    public func location(in entity: RealityKit.Entity?) -> Swift.SIMD3<Swift.Float>? { nil }
 
 }
 

--- a/Sources/RealityKitt/RealityKit/RealityKit.EntityRotationGestureRecognizer+Simulator.swift
+++ b/Sources/RealityKitt/RealityKit/RealityKit.EntityRotationGestureRecognizer+Simulator.swift
@@ -1,12 +1,12 @@
 #if targetEnvironment(simulator)
 
 import UIKit
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.0, *)
 open class EntityRotationGestureRecognizer : UIKit.UIRotationGestureRecognizer, EntityGestureRecognizer {
 
-    public var entity: RealityFoundation.HasCollision?
+    public var entity: RealityKit.HasCollision?
 
 }
 

--- a/Sources/RealityKitt/RealityKit/RealityKit.EntityScaleGestureRecognizer+Simulator.swift
+++ b/Sources/RealityKitt/RealityKit/RealityKit.EntityScaleGestureRecognizer+Simulator.swift
@@ -1,11 +1,11 @@
 #if targetEnvironment(simulator)
 import UIKit
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.0, *)
 open class EntityScaleGestureRecognizer : UIKit.UIPinchGestureRecognizer, EntityGestureRecognizer {
 
-    public var entity: RealityFoundation.HasCollision?
+    public var entity: RealityKit.HasCollision?
 
 }
 

--- a/Sources/RealityKitt/RealityKit/RealityKit.EntityTranslationGestureRecognizer+Simulator.swift
+++ b/Sources/RealityKitt/RealityKit/RealityKit.EntityTranslationGestureRecognizer+Simulator.swift
@@ -2,18 +2,18 @@
 
 import UIKit
 import RealityKit
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.0, *)
 open class EntityTranslationGestureRecognizer : UIKit.UIGestureRecognizer, EntityGestureRecognizer {
 
-    public var entity: RealityFoundation.HasCollision?
+    public var entity: RealityKit.HasCollision?
 
-    open func translation(in entity: RealityFoundation.Entity?) -> Swift.SIMD3<Swift.Float>? { nil }
+    open func translation(in entity: RealityKit.Entity?) -> Swift.SIMD3<Swift.Float>? { nil }
 
     open func setTranslation(_ translation: Swift.SIMD3<Swift.Float>, in: RealityKit.Entity?) { }
 
-    open func velocity(in entity: RealityFoundation.Entity?) -> Swift.SIMD3<Swift.Float> { .zero }
+    open func velocity(in entity: RealityKit.Entity?) -> Swift.SIMD3<Swift.Float> { .zero }
 }
 
 #endif

--- a/Tests/RealityKittTests/RealityFoundation/RealityFoundation.AnchorEntityTests.swift
+++ b/Tests/RealityKittTests/RealityFoundation/RealityFoundation.AnchorEntityTests.swift
@@ -1,19 +1,19 @@
 import XCTest
 
-import RealityFoundation
+import RealityKit
 
-// MARK: - RealityFoundation.AnchorEntity + Initializer
+// MARK: - RealityKit.AnchorEntity + Initializer
 
 @available(iOS 13.0, *)
 final class RealityFoundationAnchorEntityTests: XCTestCase {
 
     func testInitializerAvailability_init_plane_classification_minimumBounds() {
-        _ = RealityFoundation.AnchorEntity(plane: .any)
-        _ = RealityFoundation.AnchorEntity.init(plane: .any)
-        _ = RealityFoundation.AnchorEntity(plane: .any, classification: .any)
-        _ = RealityFoundation.AnchorEntity.init(plane: .any, classification: .any)
-        _ = RealityFoundation.AnchorEntity(plane: .any, classification: .any, minimumBounds: [0, 0])
-        _ = RealityFoundation.AnchorEntity.init(plane: .any, classification: .any, minimumBounds: [0, 0])
+        _ = { RealityKit.AnchorEntity(plane: .any) }
+        _ = { RealityKit.AnchorEntity.init(plane: .any) }
+        _ = { RealityKit.AnchorEntity(plane: .any, classification: .any) }
+        _ = { RealityKit.AnchorEntity.init(plane: .any, classification: .any) }
+        _ = { RealityKit.AnchorEntity(plane: .any, classification: .any, minimumBounds: [0, 0]) }
+        _ = { RealityKit.AnchorEntity.init(plane: .any, classification: .any, minimumBounds: [0, 0]) }
     }
 
 }

--- a/Tests/RealityKittTests/RealityFoundation/RealityFoundation.AnchoringComponentTests.swift
+++ b/Tests/RealityKittTests/RealityFoundation/RealityFoundation.AnchoringComponentTests.swift
@@ -1,46 +1,46 @@
 import XCTest
 
-import RealityFoundation
+import RealityKit
 
-// MARK: - RealityFoundation.AnchoringComponent.Target
+// MARK: - RealityKit.AnchoringComponent.Target
 
 @available(iOS 13.0, *)
 final class RealityFoundationAnchoringComponentTargetTests: XCTestCase {
 
-    typealias Target = RealityFoundation.AnchoringComponent.Target
+    typealias Target = RealityKit.AnchoringComponent.Target
 
     func testEnumCaseAvailability_anchor() {
-        _ = Target.anchor(identifier: UUID())
+        _ = { Target.anchor(identifier: UUID()) }
     }
 
     func testEnumCaseAvailability_plane() {
-        _ = Target.plane(.any, classification: .any, minimumBounds: [0, 0])
+        _ = { Target.plane(.any, classification: .any, minimumBounds: [0, 0]) }
     }
 
     func testEnumCaseAvailability_image() {
-        _ = Target.image(group: "🎨", name: "👨‍🎨")
+        _ = { Target.image(group: "🎨", name: "👨‍🎨") }
     }
 
     func testEnumCaseAvailability_group() {
-        _ = Target.image(group: "👫", name: "🤷‍♂️")
+        _ = { Target.image(group: "👫", name: "🤷‍♂️") }
     }
 
     func testEnumCaseAvailability_face() {
-        _ = Target.face
+        _ = { Target.face }
     }
 
     func testEnumCase_body() {
-        _ = Target.body
+        _ = { Target.body }
     }
 
 }
 
-// MARK: - RealityFoundation.AnchoringComponent.Target.Alignment
+// MARK: - RealityKit.AnchoringComponent.Target.Alignment
 
 @available(iOS 13.0, *)
 final class RealityFoundationAnchoringComponentTargetAlignmentTests: XCTestCase {
 
-    typealias Alignment = RealityFoundation.AnchoringComponent.Target.Alignment
+    typealias Alignment = RealityKit.AnchoringComponent.Target.Alignment
 
     func testOptionAvailability_horizontal() {
         XCTAssertEqual(1, Alignment.horizontal.rawValue)
@@ -56,12 +56,12 @@ final class RealityFoundationAnchoringComponentTargetAlignmentTests: XCTestCase 
 
 }
 
-// MARK: - RealityFoundation.AnchoringComponent.Target.Classification
+// MARK: - RealityKit.AnchoringComponent.Target.Classification
 
 @available(iOS 13.0, *)
 final class RealityFoundationAnchoringComponentTargetClassificationTests: XCTestCase {
 
-    typealias Classification = RealityFoundation.AnchoringComponent.Target.Classification
+    typealias Classification = RealityKit.AnchoringComponent.Target.Classification
 
     func testOptionAvailability_wall() {
         XCTAssertEqual(1, Classification.wall.rawValue)

--- a/Tests/RealityKittTests/RealityFoundation/RealityFoundation.BodyTrackedEntityTests.swift
+++ b/Tests/RealityKittTests/RealityFoundation/RealityFoundation.BodyTrackedEntityTests.swift
@@ -1,21 +1,21 @@
 import XCTest
 
 import RealityKitt
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.0, *)
 final class RealityFoundationBodyTrackedEntityTests: XCTestCase {
 
     func testBaseClass() {
-        _ = BodyTrackedEntity() as Entity
+        _ = { BodyTrackedEntity() as Entity }
     }
 
     func testProtocolConformance_Hashable() {
-        _ = BodyTrackedEntity().hashValue
+        _ = { BodyTrackedEntity().hashValue  }
     }
 
     func testProtocolConformance_HasBodyTracking() {
-        _ = BodyTrackedEntity().bodyTracking
+        _ = { BodyTrackedEntity().bodyTracking  }
     }
 
 }

--- a/Tests/RealityKittTests/RealityFoundation/RealityFoundation.BodyTrackingComponentTests.swift
+++ b/Tests/RealityKittTests/RealityFoundation/RealityFoundation.BodyTrackingComponentTests.swift
@@ -1,48 +1,48 @@
 import XCTest
 
 import RealityKitt
-import RealityFoundation
+import RealityKit
 
-// MARK: - RealityFoundation.BodyTrackingComponent
+// MARK: - RealityKit.BodyTrackingComponent
 
 @available(iOS 13.0, *)
 final class RealityFoundationBodyTrackingComponentTests: XCTestCase {
 
     func testInitializerAvailability_init() {
-        _ = BodyTrackingComponent()
-        _ = BodyTrackingComponent.init()
+        _ = { BodyTrackingComponent() }
+        _ = { BodyTrackingComponent.init() }
     }
 
     func testInitializerAvailability_init_target() {
-        _ = BodyTrackingComponent(.any)
-        _ = BodyTrackingComponent.init(.any)
+        _ = { BodyTrackingComponent(.any) }
+        _ = { BodyTrackingComponent.init(.any) }
     }
 
     func testTypePropertyAvailability_target() {
-        _ = BodyTrackingComponent().target
+        _ = { BodyTrackingComponent().target }
     }
 
     func testTypePropertyAvailability_isPaused() {
-        _ = BodyTrackingComponent().isPaused
+        _ = { BodyTrackingComponent().isPaused }
     }
 
 }
 
-// MARK: - RealityFoundation.BodyTrackingComponent + Target
+// MARK: - RealityKit.BodyTrackingComponent + Target
 
 @available(iOS 13.0, *)
 final class RealityFoundationBodyTrackingComponentTargetTests: XCTestCase {
 
     func testEnumCaseAvailability_body() {
-        _ = BodyTrackingComponent.Target.body(identifier: UUID())
+        _ = { BodyTrackingComponent.Target.body(identifier: UUID()) }
     }
 
     func testEnumCaseAvailability_any() {
-        _ = BodyTrackingComponent.Target.any
+        _ = { BodyTrackingComponent.Target.any }
     }
 
     func testProtocolConformance_Hashable() {
-        _ = BodyTrackingComponent.Target.any.hashValue
+        _ = { BodyTrackingComponent.Target.any.hashValue }
     }
 
 }

--- a/Tests/RealityKittTests/RealityFoundation/RealityFoundation.EntityTests.swift
+++ b/Tests/RealityKittTests/RealityFoundation/RealityFoundation.EntityTests.swift
@@ -1,14 +1,14 @@
 import XCTest
 
+import RealityKit
 import RealityKitt
-import RealityFoundation
 
 @available(iOS 13.0, *)
 final class RealityFoundationEntityTests: XCTestCase {
 
     func testTypeMethodAvailability_loadBodyTracked_named_in() throws {
-        let _: BodyTrackedEntity = try Entity.loadBodyTracked(named: "💃")
-        let _: BodyTrackedEntity = try Entity.loadBodyTracked(named: "🕺", in: .main)
+        let _: () throws -> BodyTrackedEntity = { try Entity.loadBodyTracked(named: "💃") }
+        let _: () throws -> BodyTrackedEntity = { try Entity.loadBodyTracked(named: "🕺", in: .main) }
     }
 
     func testTypeMethodAvailability_loadBodyTrackedAsync_named_in() {
@@ -26,8 +26,8 @@ final class RealityFoundationEntityTests: XCTestCase {
 
     func testTypeMethodAvailability_loadBodyTracked_contentsOf_withName() throws {
         let url = URL(fileURLWithPath: "/tmp/model.usdz")
-        let _: BodyTrackedEntity = try Entity.loadBodyTracked(contentsOf: url)
-        let _: BodyTrackedEntity = try Entity.loadBodyTracked(contentsOf: url, withName: "💃")
+        let _: () throws -> BodyTrackedEntity = { try Entity.loadBodyTracked(contentsOf: url) }
+        let _: () throws -> BodyTrackedEntity = { try Entity.loadBodyTracked(contentsOf: url, withName: "💃") }
     }
 
     func testTypeMethodAvailability_loadBodyTrackedAsync_contentsOf_withName() {

--- a/Tests/RealityKittTests/RealityFoundation/RealityFoundation.HasBodyTrackingTests.swift
+++ b/Tests/RealityKittTests/RealityFoundation/RealityFoundation.HasBodyTrackingTests.swift
@@ -1,19 +1,19 @@
 import XCTest
 
+import RealityKit
 import RealityKitt
-import RealityFoundation
 
 @available(iOS 13.0, *)
 final class RealityFoundationHasBodyTrackingTests: XCTestCase {
 
     func testProtocolAvailability() {
         class Implementation: Entity, HasBodyTracking { }
-        _ = Implementation()
+        _ = { Implementation() }
     }
 
     func testInstancePropertyAvailability_bodyTracking() {
         class Implementation: Entity, HasBodyTracking { }
-        _ = Implementation().bodyTracking
+        _ = { Implementation().bodyTracking }
     }
 
 }

--- a/Tests/RealityKittTests/RealityFoundation/RealityFoundation.HasSceneUnderstandingTests.swift
+++ b/Tests/RealityKittTests/RealityFoundation/RealityFoundation.HasSceneUnderstandingTests.swift
@@ -1,21 +1,21 @@
 import XCTest
 
+import RealityKit
 import RealityKitt
-import RealityFoundation
 
-// MARK: - RealityFoundation.HasSceneUnderstanding
+// MARK: - RealityKit.HasSceneUnderstanding
 
 @available(iOS 13.4, *)
 final class RealityFoundationHasSceneUnderstandingTests: XCTestCase {
 
     func testProtocolAvailability() {
-        class Implementation: RealityFoundation.Entity, HasSceneUnderstanding { }
-        _ = Implementation()
+        class Implementation: RealityKit.Entity, HasSceneUnderstanding { }
+        _ = { Implementation() }
     }
 
     func testInstanceProperty_sceneUnderstanding() {
-        class Implementation: RealityFoundation.Entity, HasSceneUnderstanding { }
-        _ = Implementation().sceneUnderstanding
+        class Implementation: RealityKit.Entity, HasSceneUnderstanding { }
+        _ = { Implementation().sceneUnderstanding }
 
     }
 

--- a/Tests/RealityKittTests/RealityFoundation/RealityFoundation.SceneUnderstandingComponentTests.swift
+++ b/Tests/RealityKittTests/RealityFoundation/RealityFoundation.SceneUnderstandingComponentTests.swift
@@ -1,32 +1,32 @@
 import XCTest
 
+import RealityKit
 import RealityKitt
-import RealityFoundation
 
-// MARK: - RealityFoundation.SceneUnderstandingComponent
+// MARK: - RealityKit.SceneUnderstandingComponent
 
 @available(iOS 13.4, *)
 final class RealityFoundationSceneUnderstandingComponentTests: XCTestCase {
 
     func testInitializerAvailability_init() {
-        _ = SceneUnderstandingComponent()
-        _ = SceneUnderstandingComponent.init()
+        _ = { SceneUnderstandingComponent() }
+        _ = { SceneUnderstandingComponent.init() }
     }
 
     func testInitializerAvailability_init_entityType() {
-        _ = SceneUnderstandingComponent(entityType: nil)
-        _ = SceneUnderstandingComponent.init(entityType: nil)
-        _ = SceneUnderstandingComponent(entityType: .face)
-        _ = SceneUnderstandingComponent.init(entityType: .face)
+        _ = { SceneUnderstandingComponent(entityType: nil) }
+        _ = { SceneUnderstandingComponent.init(entityType: nil) }
+        _ = { SceneUnderstandingComponent(entityType: .face) }
+        _ = { SceneUnderstandingComponent.init(entityType: .face) }
     }
 
     func testInstancePropertyAvailability_entityType() {
-        _ = SceneUnderstandingComponent().entityType
+        _ = { SceneUnderstandingComponent().entityType  }
     }
 
 }
 
-// MARK: - RealityFoundation.SceneUnderstandingComponent.EntityType
+// MARK: - RealityKit.SceneUnderstandingComponent.EntityType
 
 @available(iOS 13.4, *)
 final class RealityFoundationSceneUnderstandingComponentEntityTypeTests: XCTestCase {
@@ -34,15 +34,15 @@ final class RealityFoundationSceneUnderstandingComponentEntityTypeTests: XCTestC
     typealias EntityType = SceneUnderstandingComponent.EntityType
 
     func testEnumCaseAvailability_face() {
-        _ = EntityType.face
+        _ = { EntityType.face }
     }
 
     func testEnumCaseAvailability_meshChunk() {
-        _ = EntityType.meshChunk
+        _ = { EntityType.meshChunk }
     }
 
     func testProtocolConformance_Hashable() {
-        _ = EntityType.face.hashValue
+        _ = { EntityType.face.hashValue }
     }
 
 }

--- a/Tests/RealityKittTests/RealityKit/RealityKit.ARViewTests.swift
+++ b/Tests/RealityKittTests/RealityKit/RealityKit.ARViewTests.swift
@@ -9,11 +9,11 @@ import RealityKitt
 final class RealityKitARViewInitializerTests: XCTestCase {
 
     func testInitializerAvailability_init_frame_cameraMode_automaticallyConfigureSession() {
-        _ = RealityKit.ARView(frame: .zero, cameraMode: .ar, automaticallyConfigureSession: true)
+        _ = { RealityKit.ARView(frame: .zero, cameraMode: .ar, automaticallyConfigureSession: true) }
     }
 
     func testInitializerAvailability_init_frame_cameraMode() {
-        _ = RealityKit.ARView(frame: .zero, cameraMode: .nonAR)
+        _ = { RealityKit.ARView(frame: .zero, cameraMode: .nonAR) }
     }
 
 }
@@ -66,7 +66,7 @@ final class RealityKitARViewEnvironmentTests: XCTestCase {
     typealias SceneUnderstanding = RealityKit.ARView.Environment.SceneUnderstanding
 
     func testInstancePropertyAvailability_sceneUnderstanding() {
-        let _: SceneUnderstanding = RealityKit.ARView(frame: .zero).environment.sceneUnderstanding
+        let _: () -> SceneUnderstanding = { RealityKit.ARView(frame: .zero).environment.sceneUnderstanding }
     }
 
     func testInstancePropertyMutability_sceneUnderstanding() {
@@ -84,11 +84,11 @@ final class RealityKitARviewEnvironmentSceneUnderstandingTests: XCTestCase {
     typealias Options = RealityKit.ARView.Environment.SceneUnderstanding.Options
 
     func testInstancePropertyAvailability_options() {
-        let _: Options = RealityKit.ARView(frame: .zero).environment.sceneUnderstanding.options
+        let _: () -> Options = { RealityKit.ARView(frame: .zero).environment.sceneUnderstanding.options }
     }
 
     func testInstancePropertyMutability_options() {
-        RealityKit.ARView(frame: .zero).environment.sceneUnderstanding.options = .default
+        _ = { RealityKit.ARView(frame: .zero).environment.sceneUnderstanding.options = .default }
     }
 
 }
@@ -130,11 +130,11 @@ final class RealityKitARViewRenderOptionsTests: XCTestCase {
     // MARK: ARView
 
     func testInstancePropertyAvailability_renderOptions() {
-        let _: RenderOptions = RealityKit.ARView(frame: .zero).renderOptions
+        let _: () -> RenderOptions = { RealityKit.ARView(frame: .zero).renderOptions }
     }
 
     func testInstancePropertyMutability_renderOptions() {
-        RealityKit.ARView(frame: .zero).renderOptions = [.disableFaceMesh, .disableAREnvironmentLighting]
+        _ = { RealityKit.ARView(frame: .zero).renderOptions = [.disableFaceMesh, .disableAREnvironmentLighting] }
     }
 
     // MARK: ARView.RenderOptions
@@ -187,7 +187,9 @@ final class RealityKitARViewRenderOptionsTests: XCTestCase {
 final class RealityKitARViewHitTestingTests: XCTestCase {
 
     func testInstanceMethodAvailability_hitTest() {
-        let _: [ARHitTestResult] = RealityKit.ARView(frame: .zero).hitTest(.zero, types: .estimatedHorizontalPlane)
+        let _: () -> [ARHitTestResult] = {
+            RealityKit.ARView(frame: .zero).hitTest(.zero, types: .estimatedHorizontalPlane)
+        }
     }
 
 }
@@ -198,21 +200,27 @@ final class RealityKitARViewHitTestingTests: XCTestCase {
 final class RealityKitARViewRaycastingTests: XCTestCase {
 
     func testInstanceMethodAvailability_makeRaycastQuery() {
-        let view = RealityKit.ARView(frame: .zero)
-        let _: ARKit.ARRaycastQuery? = view.makeRaycastQuery(from: .zero, allowing: .estimatedPlane, alignment: .any)
+        let _: () -> ARKit.ARRaycastQuery? = {
+            let view = RealityKit.ARView(frame: .zero)
+            return view.makeRaycastQuery(from: .zero, allowing: .estimatedPlane, alignment: .any)
+        }
     }
 
     func testInstanceMethodPresence_trackedRaycast() {
-        let view = RealityKit.ARView(frame: .zero)
-        let _: ARKit.ARTrackedRaycast? = view.trackedRaycast(from: .zero,
-                                                             allowing: .estimatedPlane,
-                                                             alignment: .any,
-                                                             updateHandler: { _ in })
+        let _: () -> ARKit.ARTrackedRaycast? = {
+            let view = RealityKit.ARView(frame: .zero)
+            return view.trackedRaycast(from: .zero,
+                                       allowing: .estimatedPlane,
+                                       alignment: .any,
+                                       updateHandler: { _ in })
+        }
     }
 
     func testInstanceMethodPresence_raycast() {
-        let view = RealityKit.ARView(frame: .zero)
-        let _: [ARKit.ARRaycastResult] = view.raycast(from: .zero, allowing: .estimatedPlane, alignment: .any)
+        let _: () -> [ARKit.ARRaycastResult] = {
+            let view = RealityKit.ARView(frame: .zero)
+            return view.raycast(from: .zero, allowing: .estimatedPlane, alignment: .any)
+        }
     }
 
 }
@@ -227,11 +235,11 @@ final class RealityKitARViewCameraModeTests: XCTestCase {
     // MARK: RealityKit.ARView
 
     func testInstancePropertyAvailability_cameraMode() {
-        let _: CameraMode = RealityKit.ARView(frame: .zero).cameraMode
+        let _: () -> CameraMode = { RealityKit.ARView(frame: .zero).cameraMode }
     }
 
     func testInstancePropertyMutability_cameraMode() {
-        RealityKit.ARView(frame: .zero).cameraMode = .ar
+        _ = { RealityKit.ARView(frame: .zero).cameraMode = .ar }
     }
 
     // MARK: RealityKit.ARView.CameraMode
@@ -252,19 +260,19 @@ final class RealityKitARViewCameraModeTests: XCTestCase {
 final class RealityKitARViewSessionTests: XCTestCase {
 
     func testInstancePropertyAvailability_session() {
-        let _: ARKit.ARSession = RealityKit.ARView(frame: .zero).session
+        let _: () -> ARKit.ARSession = { RealityKit.ARView(frame: .zero).session }
     }
 
     func testInstancePropertyMutability_session() {
-        RealityKit.ARView(frame: .zero).session = ARKit.ARSession()
+        _ = { RealityKit.ARView(frame: .zero).session = ARKit.ARSession() }
     }
 
     func testInstancePropertyAvailability_automaticallyConfigureSession() {
-        let _: Swift.Bool = RealityKit.ARView(frame: .zero).automaticallyConfigureSession
+        let _: () -> Swift.Bool = { RealityKit.ARView(frame: .zero).automaticallyConfigureSession }
     }
 
     func testInstancePropertyMutability_automaticallyConfigureSession() {
-        RealityKit.ARView(frame: .zero).automaticallyConfigureSession = true
+        _ = { RealityKit.ARView(frame: .zero).automaticallyConfigureSession = true }
     }
 
     func testProtocolConformance_ARSessionProviding() {

--- a/Tests/RealityKittTests/RealityKit/RealityKit.AnchorEntityTests.swift
+++ b/Tests/RealityKittTests/RealityKit/RealityKit.AnchorEntityTests.swift
@@ -2,24 +2,22 @@ import XCTest
 
 import ARKit
 import RealityKit
-import RealityFoundation
+import RealityKitt
 
 @available(iOS 13.0, *)
 final class RealityKitAnchorEntityTests: XCTestCase {
 
     func testInitializerAvailability_init_anchor() {
-        _ = AnchorEntity(anchor: ARAnchor(name: "⚓︎", transform: matrix_identity_float4x4))
-        _ = AnchorEntity.init(anchor: ARAnchor(name: "⚓︎", transform: matrix_identity_float4x4))
+        _ = { AnchorEntity(anchor: ARAnchor(name: "⚓︎", transform: matrix_identity_float4x4)) }
+        _ = { AnchorEntity.init(anchor: ARAnchor(name: "⚓︎", transform: matrix_identity_float4x4))  }
     }
 
     func testInitializerAvailability_init_raycastResult() {
-        let _ : (ARKit.ARRaycastResult) -> RealityFoundation.AnchorEntity = {
-            // ToDo: Explain why needed : ARRaycastResult not instanicable ...
-            RealityFoundation.AnchorEntity(raycastResult: $0)
+        let _ : (ARKit.ARRaycastResult) -> RealityKit.AnchorEntity = {
+            RealityKit.AnchorEntity(raycastResult: $0)
         }
-        let _ : (ARKit.ARRaycastResult) -> RealityFoundation.AnchorEntity = {
-            // ToDo: Explain why needed : ARRaycastResult not instanicable ...
-            RealityFoundation.AnchorEntity.init(raycastResult: $0)
+        let _ : (ARKit.ARRaycastResult) -> RealityKit.AnchorEntity = {
+            RealityKit.AnchorEntity.init(raycastResult: $0)
         }
     }
 

--- a/Tests/RealityKittTests/RealityKit/RealityKit.AnchoringComponentTests.swift
+++ b/Tests/RealityKittTests/RealityKit/RealityKit.AnchoringComponentTests.swift
@@ -1,14 +1,14 @@
 import XCTest
 
 import ARKit
-import RealityFoundation
+import RealityKit
 
 @available(iOS 13.0, *)
 final class RealityKitAnchoringComponentTests: XCTestCase {
 
     func testInitializerAvailability_init_anchor() {
-        _ = RealityFoundation.AnchoringComponent(ARKit.ARAnchor(transform: matrix_identity_float4x4))
-        _ = RealityFoundation.AnchoringComponent.init(ARKit.ARAnchor(transform: matrix_identity_float4x4))
+        _ = { RealityKit.AnchoringComponent(ARKit.ARAnchor(transform: matrix_identity_float4x4)) }
+        _ = { RealityKit.AnchoringComponent.init(ARKit.ARAnchor(transform: matrix_identity_float4x4)) }
     }
 
 }

--- a/Tests/RealityKittTests/RealityKit/RealityKit.EntityGestureRecognizerTests.swift
+++ b/Tests/RealityKittTests/RealityKit/RealityKit.EntityGestureRecognizerTests.swift
@@ -3,7 +3,6 @@ import XCTest
 import UIKit
 import RealityKit
 import RealityKitt
-import RealityFoundation
 
 @available(iOS 13.0, *)
 final class RealityKitEntityGestureRecognizerTests: XCTestCase {
@@ -26,7 +25,7 @@ final class RealityKitEntityGestureRecognizerTests: XCTestCase {
 @available(iOS 13.0, *)
 private class GestureMock: UIKit.UIGestureRecognizer, EntityGestureRecognizer {
 
-    var entity: RealityFoundation.HasCollision?
+    var entity: RealityKit.HasCollision?
 
     init() {
         super.init(target: nil, action: nil)

--- a/Tests/RealityKittTests/RealityKit/RealityKit.EntityTranslationGestureRecognizerTests.swift
+++ b/Tests/RealityKittTests/RealityKit/RealityKit.EntityTranslationGestureRecognizerTests.swift
@@ -37,14 +37,14 @@ final class RealityKitEntityTranslationGestureRecognizerTests: XCTestCase {
 
     func testSubclassMethodOverriding_translation() {
         class Subclass: EntityTranslationGestureRecognizer {
-            override func translation(in entity: RealityFoundation.Entity?) -> Swift.SIMD3<Swift.Float>? {  [0, 0, 0] }
+            override func translation(in entity: RealityKit.Entity?) -> Swift.SIMD3<Swift.Float>? {  [0, 0, 0] }
         }
         _ = Subclass(target: nil, action: nil)
     }
 
     func testSubclassMethodOverriding_setTranslation() {
         class Subclass: EntityTranslationGestureRecognizer {
-            override func setTranslation(_ translation: Swift.SIMD3<Swift.Float>, in: RealityFoundation.Entity?) { }
+            override func setTranslation(_ translation: Swift.SIMD3<Swift.Float>, in: RealityKit.Entity?) { }
         }
         _ = Subclass(target: nil, action: nil)
     }


### PR DESCRIPTION
The Xcode 13 beta exposed the framework 'RealityFoundation'.
The initial version of this library made use of this split
of 'RealityKit' and 'RealityFoundation' features.

This commit removes the usage of 'RealityFoundation' to provide
a seamless backward compatibility with older Xcode/Swift versions.

Follow-up: Remove the split from the '+Simulator.swift' files.