### PR TITLE
Tests: Reworked the tests to leverage Xcode 12.5 and macOS 11

### DIFF
--- a/Tests/RealityKittTests/ARViewTests.swift
+++ b/Tests/RealityKittTests/ARViewTests.swift
@@ -9,11 +9,11 @@ import RealityKitt
 final class ARViewInitializerTests: XCTestCase {
 
     func testInitializerAvailability_init_frame_cameraMode_automaticallyConfigureSession() {
-        _ = { RealityKit.ARView(frame: .zero, cameraMode: .ar, automaticallyConfigureSession: true) }
+        _ = RealityKit.ARView(frame: .zero, cameraMode: .ar, automaticallyConfigureSession: true)
     }
 
     func testInitializerAvailability_init_frame_cameraMode() {
-        _ = { RealityKit.ARView(frame: .zero, cameraMode: .nonAR) }
+        _ = RealityKit.ARView(frame: .zero, cameraMode: .nonAR)
     }
 
 }
@@ -70,10 +70,8 @@ final class ARViewEnvironmentTests: XCTestCase {
     }
 
     func testInstancePropertyMutability_sceneUnderstanding() {
-        _ = {
-            let sceneUnderstanding = RealityKit.ARView(frame: .zero).environment.sceneUnderstanding
-            RealityKit.ARView(frame: .zero).environment.sceneUnderstanding = sceneUnderstanding
-        }
+        let sceneUnderstanding = RealityKit.ARView(frame: .zero).environment.sceneUnderstanding
+        RealityKit.ARView(frame: .zero).environment.sceneUnderstanding = sceneUnderstanding
     }
 
 }
@@ -84,11 +82,11 @@ final class ARviewEnvironmentSceneUnderstandingTests: XCTestCase {
     typealias Options = RealityKit.ARView.Environment.SceneUnderstanding.Options
 
     func testInstancePropertyAvailability_options() {
-        let _: () -> Options = { RealityKit.ARView(frame: .zero).environment.sceneUnderstanding.options }
+        let _: Options = RealityKit.ARView(frame: .zero).environment.sceneUnderstanding.options
     }
 
     func testInstancePropertyMutability_options() {
-        _ = { RealityKit.ARView(frame: .zero).environment.sceneUnderstanding.options = .default }
+        _ = RealityKit.ARView(frame: .zero).environment.sceneUnderstanding.options = .default
     }
 
 }
@@ -130,11 +128,11 @@ final class ARViewRenderOptionsTests: XCTestCase {
     // MARK: ARView
 
     func testInstancePropertyAvailability_renderOptions() {
-        let _: () -> RenderOptions = { RealityKit.ARView(frame: .zero).renderOptions }
+        let _: RenderOptions = RealityKit.ARView(frame: .zero).renderOptions
     }
 
     func testInstancePropertyMutability_renderOptions() {
-        _ = { RealityKit.ARView(frame: .zero).renderOptions = [.disableHDR, .disableAREnvironmentLighting] }
+        _ = RealityKit.ARView(frame: .zero).renderOptions = [.disableHDR, .disableAREnvironmentLighting]
     }
 
     // MARK: ARView.RenderOptions

--- a/Tests/RealityKittTests/AnchorEntityTests.swift
+++ b/Tests/RealityKittTests/AnchorEntityTests.swift
@@ -8,17 +8,17 @@ import RealityKitt
 final class AnchorEntityTests: XCTestCase {
 
     func testInitializerAvailability_init_plane_classification_minimumBounds() {
-        _ = { RealityKit.AnchorEntity(plane: .any) }
-        _ = { RealityKit.AnchorEntity.init(plane: .any) }
-        _ = { RealityKit.AnchorEntity(plane: .any, classification: .any) }
-        _ = { RealityKit.AnchorEntity.init(plane: .any, classification: .any) }
-        _ = { RealityKit.AnchorEntity(plane: .any, classification: .any, minimumBounds: [0, 0]) }
-        _ = { RealityKit.AnchorEntity.init(plane: .any, classification: .any, minimumBounds: [0, 0]) }
+        _ = RealityKit.AnchorEntity(plane: .any)
+        _ = RealityKit.AnchorEntity.init(plane: .any)
+        _ = RealityKit.AnchorEntity(plane: .any, classification: .any)
+        _ = RealityKit.AnchorEntity.init(plane: .any, classification: .any)
+        _ = RealityKit.AnchorEntity(plane: .any, classification: .any, minimumBounds: [0, 0])
+        _ = RealityKit.AnchorEntity.init(plane: .any, classification: .any, minimumBounds: [0, 0])
     }
 
     func testInitializerAvailability_init_anchor() {
-        _ = { AnchorEntity(anchor: ARAnchor(name: "⚓︎", transform: matrix_identity_float4x4)) }
-        _ = { AnchorEntity.init(anchor: ARAnchor(name: "⚓︎", transform: matrix_identity_float4x4))  }
+        _ = RealityKit.AnchorEntity(anchor: ARAnchor(name: "⚓︎", transform: matrix_identity_float4x4))
+        _ = RealityKit.AnchorEntity.init(anchor: ARAnchor(name: "⚓︎", transform: matrix_identity_float4x4))
     }
 
     func testInitializerAvailability_init_raycastResult() {

--- a/Tests/RealityKittTests/AnchoringComponentTests.swift
+++ b/Tests/RealityKittTests/AnchoringComponentTests.swift
@@ -8,8 +8,8 @@ import RealityKitt
 final class AnchoringComponentTests: XCTestCase {
 
     func testInitializerAvailability_init_anchor() {
-        _ = { RealityKit.AnchoringComponent(ARKit.ARAnchor(transform: matrix_identity_float4x4)) }
-        _ = { RealityKit.AnchoringComponent.init(ARKit.ARAnchor(transform: matrix_identity_float4x4)) }
+        _ = RealityKit.AnchoringComponent(ARKit.ARAnchor(transform: matrix_identity_float4x4))
+        _ = RealityKit.AnchoringComponent.init(ARKit.ARAnchor(transform: matrix_identity_float4x4))
     }
 
 }
@@ -20,27 +20,27 @@ final class AnchoringComponentTargetTests: XCTestCase {
     typealias Target = RealityKit.AnchoringComponent.Target
 
     func testEnumCaseAvailability_anchor() {
-        _ = { Target.anchor(identifier: UUID()) }
+        _ = Target.anchor(identifier: UUID())
     }
 
     func testEnumCaseAvailability_plane() {
-        _ = { Target.plane(.any, classification: .any, minimumBounds: [0, 0]) }
+        _ = Target.plane(.any, classification: .any, minimumBounds: [0, 0])
     }
 
     func testEnumCaseAvailability_image() {
-        _ = { Target.image(group: "🎨", name: "👨‍🎨") }
+        _ = Target.image(group: "🎨", name: "👨‍🎨")
     }
 
     func testEnumCaseAvailability_group() {
-        _ = { Target.image(group: "👫", name: "🤷‍♂️") }
+        _ = Target.image(group: "👫", name: "🤷‍♂️")
     }
 
     func testEnumCaseAvailability_face() {
-        _ = { Target.face }
+        _ = Target.face
     }
 
     func testEnumCase_body() {
-        _ = { Target.body }
+        _ = Target.body
     }
 
 }

--- a/Tests/RealityKittTests/BodyTrackedEntityTests.swift
+++ b/Tests/RealityKittTests/BodyTrackedEntityTests.swift
@@ -7,15 +7,15 @@ import RealityKit
 final class BodyTrackedEntityTests: XCTestCase {
 
     func testBaseClass() {
-        _ = { BodyTrackedEntity() as Entity }
+        _ = BodyTrackedEntity() as Entity
     }
 
     func testProtocolConformance_Hashable() {
-        _ = { BodyTrackedEntity().hashValue  }
+        _ = BodyTrackedEntity().hashValue
     }
 
     func testProtocolConformance_HasBodyTracking() {
-        _ = { BodyTrackedEntity().bodyTracking  }
+        _ = BodyTrackedEntity().bodyTracking
     }
 
 }

--- a/Tests/RealityKittTests/BodyTrackingComponentTests.swift
+++ b/Tests/RealityKittTests/BodyTrackingComponentTests.swift
@@ -9,21 +9,21 @@ import RealityKitt
 final class BodyTrackingComponentTests: XCTestCase {
 
     func testInitializerAvailability_init() {
-        _ = { BodyTrackingComponent() }
-        _ = { BodyTrackingComponent.init() }
+        _ = BodyTrackingComponent()
+        _ = BodyTrackingComponent.init()
     }
 
     func testInitializerAvailability_init_target() {
-        _ = { BodyTrackingComponent(.any) }
-        _ = { BodyTrackingComponent.init(.any) }
+        _ = BodyTrackingComponent(.any)
+        _ = BodyTrackingComponent.init(.any)
     }
 
     func testTypePropertyAvailability_target() {
-        _ = { BodyTrackingComponent().target }
+        _ = BodyTrackingComponent().target
     }
 
     func testTypePropertyAvailability_isPaused() {
-        _ = { BodyTrackingComponent().isPaused }
+        _ = BodyTrackingComponent().isPaused
     }
 
 }
@@ -34,15 +34,15 @@ final class BodyTrackingComponentTests: XCTestCase {
 final class BodyTrackingComponentTargetTests: XCTestCase {
 
     func testEnumCaseAvailability_body() {
-        _ = { BodyTrackingComponent.Target.body(identifier: UUID()) }
+        _ = BodyTrackingComponent.Target.body(identifier: UUID())
     }
 
     func testEnumCaseAvailability_any() {
-        _ = { BodyTrackingComponent.Target.any }
+        _ = BodyTrackingComponent.Target.any
     }
 
     func testProtocolConformance_Hashable() {
-        _ = { BodyTrackingComponent.Target.any.hashValue }
+        _ = BodyTrackingComponent.Target.any.hashValue
     }
 
 }

--- a/Tests/RealityKittTests/EntityTests.swift
+++ b/Tests/RealityKittTests/EntityTests.swift
@@ -7,8 +7,8 @@ import RealityKitt
 final class EntityTests: XCTestCase {
 
     func testTypeMethodAvailability_loadBodyTracked_named_in() throws {
-        let _: () throws -> BodyTrackedEntity = { try Entity.loadBodyTracked(named: "💃") }
-        let _: () throws -> BodyTrackedEntity = { try Entity.loadBodyTracked(named: "🕺", in: .main) }
+        _ = try Entity.loadBodyTracked(named: "💃")
+        _ = try Entity.loadBodyTracked(named: "🕺", in: .main)
     }
 
     func testTypeMethodAvailability_loadBodyTrackedAsync_named_in() {
@@ -26,8 +26,8 @@ final class EntityTests: XCTestCase {
 
     func testTypeMethodAvailability_loadBodyTracked_contentsOf_withName() throws {
         let url = URL(fileURLWithPath: "/tmp/model.usdz")
-        let _: () throws -> BodyTrackedEntity = { try Entity.loadBodyTracked(contentsOf: url) }
-        let _: () throws -> BodyTrackedEntity = { try Entity.loadBodyTracked(contentsOf: url, withName: "💃") }
+        _ = try Entity.loadBodyTracked(contentsOf: url)
+        _ = try Entity.loadBodyTracked(contentsOf: url, withName: "💃")
     }
 
     func testTypeMethodAvailability_loadBodyTrackedAsync_contentsOf_withName() {

--- a/Tests/RealityKittTests/HasBodyTrackingTests.swift
+++ b/Tests/RealityKittTests/HasBodyTrackingTests.swift
@@ -8,12 +8,12 @@ final class HasBodyTrackingTests: XCTestCase {
 
     func testProtocolAvailability() {
         class Implementation: Entity, HasBodyTracking { }
-        _ = { Implementation() }
+        _ = Implementation()
     }
 
     func testInstancePropertyAvailability_bodyTracking() {
         class Implementation: Entity, HasBodyTracking { }
-        _ = { Implementation().bodyTracking }
+        _ = Implementation().bodyTracking
     }
 
 }

--- a/Tests/RealityKittTests/HasSceneUnderstandingTests.swift
+++ b/Tests/RealityKittTests/HasSceneUnderstandingTests.swift
@@ -10,12 +10,12 @@ final class HasSceneUnderstandingTests: XCTestCase {
 
     func testProtocolAvailability() {
         class Implementation: RealityKit.Entity, HasSceneUnderstanding { }
-        _ = { Implementation() }
+        _ = Implementation()
     }
 
     func testInstanceProperty_sceneUnderstanding() {
         class Implementation: RealityKit.Entity, HasSceneUnderstanding { }
-        _ = { Implementation().sceneUnderstanding }
+        _ = Implementation().sceneUnderstanding
 
     }
 

--- a/Tests/RealityKittTests/SceneUnderstandingComponentTests.swift
+++ b/Tests/RealityKittTests/SceneUnderstandingComponentTests.swift
@@ -9,19 +9,19 @@ import RealityKitt
 final class SceneUnderstandingComponentTests: XCTestCase {
 
     func testInitializerAvailability_init() {
-        _ = { SceneUnderstandingComponent() }
-        _ = { SceneUnderstandingComponent.init() }
+        _ = SceneUnderstandingComponent()
+        _ = SceneUnderstandingComponent.init()
     }
 
     func testInitializerAvailability_init_entityType() {
-        _ = { SceneUnderstandingComponent(entityType: nil) }
-        _ = { SceneUnderstandingComponent.init(entityType: nil) }
-        _ = { SceneUnderstandingComponent(entityType: .face) }
-        _ = { SceneUnderstandingComponent.init(entityType: .face) }
+        _ = SceneUnderstandingComponent(entityType: nil)
+        _ = SceneUnderstandingComponent.init(entityType: nil)
+        _ = SceneUnderstandingComponent(entityType: .face)
+        _ = SceneUnderstandingComponent.init(entityType: .face)
     }
 
     func testInstancePropertyAvailability_entityType() {
-        _ = { SceneUnderstandingComponent().entityType  }
+        _ = SceneUnderstandingComponent().entityType
     }
 
 }
@@ -34,15 +34,15 @@ final class SceneUnderstandingComponentEntityTypeTests: XCTestCase {
     typealias EntityType = SceneUnderstandingComponent.EntityType
 
     func testEnumCaseAvailability_face() {
-        _ = { EntityType.face }
+        _ = EntityType.face
     }
 
     func testEnumCaseAvailability_meshChunk() {
-        _ = { EntityType.meshChunk }
+        _ = EntityType.meshChunk
     }
 
     func testProtocolConformance_Hashable() {
-        _ = { EntityType.face.hashValue }
+        _ = EntityType.face.hashValue
     }
 
 }


### PR DESCRIPTION
Previously, most (unit) tests weren't executing the code but
solely created a closure that contained the test code.

This was done because the CI/CD was running macOS 10.x and
an older version of Xcode where the tests caused crashes
because they created (Metal) objects which weren't supported
by the iOS Simulator(s) before macOS 11.